### PR TITLE
Fix Yahoo Shopping env fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ SUPABASE_SERVICE_KEY=your_supabase_service_key
 # API設定（オプション）
 DISCOGS_TOKEN=your_discogs_token
 EBAY_APP_ID=your_ebay_app_id
+# Yahoo Shopping API は YAHOO_SHOPPING_APP_ID を推奨しますが、
+# 互換性のため YAHOO_APP_ID でも利用可能です
+YAHOO_SHOPPING_APP_ID=your_yahoo_shopping_app_id
 YAHOO_APP_ID=your_yahoo_app_id
 ```
 

--- a/src/collectors/yahoo_shopping.py
+++ b/src/collectors/yahoo_shopping.py
@@ -18,7 +18,10 @@ class YahooShoppingClient:
         YahooShoppingClientを初期化します。
         環境変数から認証情報を読み込みます。
         """
-        self.app_id = get_optional_config("YAHOO_SHOPPING_APP_ID")
+        # 旧環境変数 YAHOO_APP_ID との互換性を保つため、
+        # YAHOO_SHOPPING_APP_ID が未設定の場合は YAHOO_APP_ID を使用する
+        self.app_id = get_optional_config("YAHOO_SHOPPING_APP_ID") or \
+            get_optional_config("YAHOO_APP_ID")
         self.base_url = "https://shopping.yahooapis.jp/ShoppingWebService/V3"
         self.headers = {
             "User-Agent": get_optional_config("USER_AGENT", "RecordCollector/1.0")

--- a/src/jan/unified_search_engine.ts
+++ b/src/jan/unified_search_engine.ts
@@ -44,7 +44,9 @@ export class UnifiedJanSearchEngine {
   constructor() {
     // 環境変数を取得
     this.GOOGLE_TRANSLATE_API_KEY = process.env.GOOGLE_TRANSLATE_API_KEY || '';
-    this.YAHOO_SHOPPING_APP_ID = process.env.YAHOO_SHOPPING_APP_ID || '';
+    // YAHOO_SHOPPING_APP_ID が未設定の場合は YAHOO_APP_ID をフォールバックとして使用
+    this.YAHOO_SHOPPING_APP_ID =
+      process.env.YAHOO_SHOPPING_APP_ID || process.env.YAHOO_APP_ID || '';
     this.EBAY_APP_ID = process.env.EBAY_APP_ID || '';
     
     // 環境変数の状況をログ出力


### PR DESCRIPTION
## Summary
- support both `YAHOO_SHOPPING_APP_ID` and legacy `YAHOO_APP_ID`
- document Yahoo Shopping API environment variable

## Testing
- `npm run lint` *(fails: next not found)*