### PR TITLE
Fix eBay credential fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ SUPABASE_SERVICE_KEY=your_supabase_service_key
 
 # API設定（オプション）
 DISCOGS_TOKEN=your_discogs_token
+# eBay API は EBAY_APP_ID を推奨しますが、
+# 互換性のため EBAY_CLIENT_ID または EBAY_APPID でも利用できます
 EBAY_APP_ID=your_ebay_app_id
+# Yahoo Shopping API は YAHOO_SHOPPING_APP_ID を推奨しますが、
+# 互換性のため YAHOO_APP_ID でも利用可能です
+YAHOO_SHOPPING_APP_ID=your_yahoo_shopping_app_id
 YAHOO_APP_ID=your_yahoo_app_id
 ```
 

--- a/src/collectors/ebay.py
+++ b/src/collectors/ebay.py
@@ -9,7 +9,7 @@ import json
 from typing import List, Dict, Any, Optional
 from datetime import datetime, timedelta
 import base64
-from ..utils.config import get_config
+from ..utils.config import get_config, get_optional_config
 
 class EbayClient:
     """eBay APIと通信するクライアントクラス"""
@@ -19,7 +19,10 @@ class EbayClient:
         EbayClientを初期化します。
         環境変数から認証情報を読み込みます。
         """
-        self.app_id = get_config("EBAY_APP_ID")
+        # EBAY_CLIENT_ID や旧 EBAY_APPID もフォールバックとして参照
+        self.app_id = get_optional_config("EBAY_APP_ID") or \
+            get_optional_config("EBAY_CLIENT_ID") or \
+            get_optional_config("EBAY_APPID")
         self.cert_id = get_config("EBAY_CERT_ID")
         self.client_secret = get_config("EBAY_CLIENT_SECRET")
         self.redirect_uri = get_config("EBAY_REDIRECT_URI")

--- a/src/collectors/yahoo_shopping.py
+++ b/src/collectors/yahoo_shopping.py
@@ -18,7 +18,10 @@ class YahooShoppingClient:
         YahooShoppingClientを初期化します。
         環境変数から認証情報を読み込みます。
         """
-        self.app_id = get_optional_config("YAHOO_SHOPPING_APP_ID")
+        # 旧環境変数 YAHOO_APP_ID との互換性を保つため、
+        # YAHOO_SHOPPING_APP_ID が未設定の場合は YAHOO_APP_ID を使用する
+        self.app_id = get_optional_config("YAHOO_SHOPPING_APP_ID") or \
+            get_optional_config("YAHOO_APP_ID")
         self.base_url = "https://shopping.yahooapis.jp/ShoppingWebService/V3"
         self.headers = {
             "User-Agent": get_optional_config("USER_AGENT", "RecordCollector/1.0")

--- a/src/jan/unified_search_engine.ts
+++ b/src/jan/unified_search_engine.ts
@@ -44,8 +44,15 @@ export class UnifiedJanSearchEngine {
   constructor() {
     // 環境変数を取得
     this.GOOGLE_TRANSLATE_API_KEY = process.env.GOOGLE_TRANSLATE_API_KEY || '';
-    this.YAHOO_SHOPPING_APP_ID = process.env.YAHOO_SHOPPING_APP_ID || '';
-    this.EBAY_APP_ID = process.env.EBAY_APP_ID || '';
+    // YAHOO_SHOPPING_APP_ID が未設定の場合は YAHOO_APP_ID をフォールバックとして使用
+    this.YAHOO_SHOPPING_APP_ID =
+      process.env.YAHOO_SHOPPING_APP_ID || process.env.YAHOO_APP_ID || '';
+    // EBAY_CLIENT_ID や旧 EBAY_APPID もフォールバックとして参照
+    this.EBAY_APP_ID =
+      process.env.EBAY_APP_ID ||
+      process.env.EBAY_CLIENT_ID ||
+      (process.env as any).EBAY_APPID ||
+      '';
     
     // 環境変数の状況をログ出力
     console.log(`[UNIFIED_ENGINE] Environment variables status:`);


### PR DESCRIPTION
## Summary
- document fallback environment variables for eBay API
- support EBAY_CLIENT_ID and EBAY_APPID in TypeScript unified search engine
- support EBAY_CLIENT_ID and EBAY_APPID in Python eBay collector

## Testing
- `npm run lint` *(fails: next not found)*